### PR TITLE
password should be null-terminated

### DIFF
--- a/src/PgAsync/Command/PasswordMessage.php
+++ b/src/PgAsync/Command/PasswordMessage.php
@@ -21,7 +21,7 @@ class PasswordMessage implements CommandInterface
     public function encodedMessage()
     {
 
-        return "p" . Message::prependLengthInt32($this->password);
+        return "p" . Message::prependLengthInt32($this->password . "\x00");
     }
 
     public function shouldWaitForComplete()


### PR DESCRIPTION
https://www.postgresql.org/docs/9.5/static/protocol-message-formats.html

The password (encrypted, if requested) has a "String" type in PasswordMessage packet. 

https://www.postgresql.org/docs/9.5/static/protocol-message-types.html
String datatype should be null-termindated.

Without this patch i cannot connect to my postgresql-9.5 server (via pgbouncer).