### PR TITLE
Configurable connection pool limit

### DIFF
--- a/src/PgAsync/Connection.php
+++ b/src/PgAsync/Connection.php
@@ -193,6 +193,19 @@ class Connection extends EventEmitter
         return $this->queryState;
     }
 
+    public function getBacklogLength() : int
+    {
+        return array_reduce(
+            $this->commandQueue,
+            function ($a, CommandInterface $command) {
+                if ($command instanceof Query || $command instanceof Sync) {
+                    $a++;
+                }
+                return $a;
+            },
+            0);
+    }
+
     public function onData($data)
     {
         while (strlen($data) > 0) {


### PR DESCRIPTION
This adds a connection count limit for the connection pool so users don't accidentally create 1000 connections.

Just add `max_connections` to the parameters of the client constructor. Queries are directed to the connection with the least pending commands (or an idle connection). The default is set to 5.