### PR TITLE
Forward compatibility with voryx/event-loop 3.0 and while supporting 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     }
   },
   "require": {
-    "voryx/event-loop": "^2.0.2",
+    "voryx/event-loop": "^3.0 || ^2.0.2",
     "reactivex/rxphp": "^2.0",
     "react/socket": "^1.0 || ^0.8 || ^0.7",
     "evenement/evenement": "^2.0 | ^3.0"

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -38,7 +38,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
     public static function cancelCurrentTimeoutTimer()
     {
         if (static::$timeoutTimer !== null) {
-            static::$timeoutTimer->cancel();
+            static::getLoop()->cancelTimer(static::$timeoutTimer);
             static::$timeoutTimer = null;
         }
     }


### PR DESCRIPTION
As promised at https://github.com/voryx/event-loop/pull/1#issuecomment-382123772 here is the PR that updates this package to support voryx/event-loop 3.0 and 2.0.