### PR TITLE
Always ensure we have a connection at index 0

### DIFF
--- a/src/PgAsync/Client.php
+++ b/src/PgAsync/Client.php
@@ -141,9 +141,9 @@ class Client
         $this->connections[] = $connection;
 
         $connection->on('close', function () use ($connection) {
-            $this->connections = array_filter($this->connections, function ($c) use ($connection) {
+            $this->connections = array_values(array_filter($this->connections, function ($c) use ($connection) {
                 return $connection !== $c;
-            });
+            }));
         });
 
         return $connection;


### PR DESCRIPTION
The resolves the following error that occurs occasionally: `Error: Call to a member function getBacklogLength() on null in /opt/app/vendor/voryx/pgasync/src/PgAsync/Client.php:102`